### PR TITLE
Adds Styling to PatchNotes and restyles the Downloads page

### DIFF
--- a/src/components/DownloadCard.astro
+++ b/src/components/DownloadCard.astro
@@ -1,14 +1,22 @@
 ---
 const { title, version, link } = Astro.props;
+
+const styles = {
+  div: "download-card shadow-md bg-amber-600/60 w-[20rem] h-[10rem] p-4 rounded-md border-[3px] border-white flex flex-col justify-center items-center gap-y-2",
+  h2: "text-xl font-bold",
+  a: "bg-blue-700 text-white p-2 w-1/2 text-center rounded-md shadow-sm hover:shadow-lg font-bold"
+}
+
 ---
 
-<div class="download-card">
-  <h2>{title}</h2>
+
+<div class={styles.div}>
+  <h2 class={styles.h2}>{title}</h2>
   <p>{version}</p>
-  <a href={link}>Download</a>
+  <a class={styles.a} href={link}>Download</a>
 </div>
 
-<style>
+<!-- <style>
   .download-card:hover {
     scale: 1.05;
     margin: 0px 10px;
@@ -60,4 +68,4 @@ const { title, version, link } = Astro.props;
   p {
     font-weight: bold;
   }
-</style>
+</style> -->

--- a/src/components/react/Update.jsx
+++ b/src/components/react/Update.jsx
@@ -1,0 +1,21 @@
+import React from 'react'
+
+function Update({ update }) {
+
+  const styles = {
+    div: 'min-h-[10rem] shadow-md hover:shadow-2xl hover:scale-105 bg-black/60 w-[90%] md:w-[30rem] rounded-md border-2 p-2 flex flex-col gap-y-2',
+    h1: 'text-xl italic uppercase',
+    h2: 'text-md font-bold text-slate-400',
+    p: 'font-bold'
+  }
+
+  return (
+    <div class={styles.div}>
+      <h1 class={styles.h1}>{update.version}</h1>
+      <h2 class={styles.h2}>{update.date}</h2>
+      <p class={styles.p}>{update.description}</p>
+    </div>
+  )
+}
+
+export default Update

--- a/src/pages/Download.astro
+++ b/src/pages/Download.astro
@@ -2,17 +2,25 @@
 import Layout from "../layouts/Layout.astro"
 import DownloadCard from "../components/DownloadCard.astro"
 
+const styles = {
+    h1: "font-bold text-4xl text-center my-2",
+    downloadDiv: "download w-full flex flex-col items-center gap-y-5",
+    mainContentDiv: "main-content flex flex-col justify-center gap-y-3 md:gap-y-4 bg-black/50 w-[95%] md:w-3/4 h-auto md:h-[26rem] lg:h-[23rem] p-4 rounded-md shadow-lg border-2 ",
+    olderDownloadsP: "older-version-text font-bold mt-5 mb-2 w-[70%] md:w-[30%] text-center py-2 border rounded-md shadow-md bg-black/50",
+    OlderDownloadsDiv: "older-downloads flex gap-x-5 flex-wrap justify-center gap-y-4 mb-2"
+}
+
 ---
 
 <title>Download</title>
 <Layout title="Download">
     
-    <h1>Download</h1>
+    <h1 class={styles.h1}>Download</h1>
 
-    <div class="download">
+    <div class={styles.downloadDiv}>
         <!-- download page that looks like the node.js installer page -->
-        <div class="main-content">
-            <p>Download the latest version of the CubeScript compiler for Windows.</p>
+        <div class={styles.mainContentDiv}>
+        <p>Download the latest version of the CubeScript compiler for Windows.</p>
             <p>Version 1.2</p>
             <p>The Expanse Update!</p>
             <p>This includes a .bin file within the zip file so that linux is now a supported target!!!</p>
@@ -24,9 +32,9 @@ import DownloadCard from "../components/DownloadCard.astro"
         
         <DownloadCard title={"Windows and linux"} version={"Version 1.2.2, the Expanse Update"} link={"https://github.com/charlie-sans/CVSM-Repo/releases/download/1.2.2/CubeScriptv1.2.2.zip"}  />
         
-        <p class="older-version-text">Looking for a older version?</p>
+        <p class={styles.olderDownloadsP}>Looking for a older version?</p>
         
-        <div class="older-downloads">
+        <div class={styles.OlderDownloadsDiv}>
             <DownloadCard title={"CubeScript"} version={"Version 1.2.1, the Broken Update"} link={"https://github.com/charlie-sans/CVSM-Repo/releases/download/v1.2.1/CSVM_Linux.zip"} />            
             <DownloadCard title={"CubeScript"} version={"Version 1.2"} link={"https://github.com/charlie-sans/CVSM-Repo/releases/download/v1.2/CubeScript-1.2.zip"} />
         </div>
@@ -40,11 +48,9 @@ import DownloadCard from "../components/DownloadCard.astro"
 
 * {
    font-family: Arial, Helvetica, sans-serif;
-   text-align: center;
    color: white;
-   font-size: 18px;
 }
-
+/* 
 h1 {
     font-size: 2rem;
 }
@@ -97,6 +103,6 @@ h1 {
     column-gap: 1rem;
     row-gap: 1.5rem;
     width: 100%;
-}
+} */
 
 </style>

--- a/src/pages/Patchnotes.astro
+++ b/src/pages/Patchnotes.astro
@@ -1,20 +1,40 @@
 ---
-import Notes from '../components/vue/Patchnotes.vue';
-import styles from '../components/main.scss';
+import Layout from "../layouts/Layout.astro";
+import styles from "../components/main.scss";
+import Update from "../components/react/Update.jsx";
+
+const patchnotesUrl =
+  "https://raw.githubusercontent.com/OpenStudioCorp/CubeScript/master/api/update.json";
+const fetchUpdates = await fetch(patchnotesUrl);
+const updatesData = await fetchUpdates.json();
+
+const styles = {
+  h1: "my-5 text-center text-3xl text-white font-bold",
+  div: "flex flex-col gap-y-5 w-full items-center text-white mb-4"
+}
+
 ---
 
-<body>
-  <style>
-    :root {
+<Layout title="Patchnotes">
+  <h1 class={styles.h1}>Patchnotes</h1>
+    <div class={styles.div}>
+      {
+        updatesData.map((update) => (
+            <Update update={update} />
+        ))
+      }
+    </div>
+</Layout>
+<!-- 
+<style>
+  :root {
     --background: #877895;
   }
-  body 
-  {
+  body {
     background: #877895;
     font-family: Arial, sans-serif;
     margin: 0;
     padding: 0;
-    
   }
   a {
     color: #c90000;
@@ -24,7 +44,12 @@ import styles from '../components/main.scss';
     color: #9b59b6;
     text-decoration: underline;
   }
-  h1, h2, h3, h4, h5, h6 {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
     color: #000000;
     font-weight: bold;
     font-family: Arial, sans-serif;
@@ -42,20 +67,12 @@ import styles from '../components/main.scss';
   * {
     box-sizing: border-box;
     --background: #fa;
-  
   }
-  
+
   .notes {
     margin: 0 auto;
     max-width: 800px;
     padding: 0 1rem;
-    background : var(--background);
+    background: var(--background);
   }
-  </style>
-
-<div class="notes">
-  <Notes client:load />
-</div>
-</body>
-
-
+</style> -->


### PR DESCRIPTION
Adds Styling to PatchNotes and restyles the Downloads page
Tried writing PatchNotes component in React but it didn't really work so I used Astro.
Component fetches updates / patch notes stored in a file in the repo
Represents each update / version / patch as a card
Styling done in Tailwind